### PR TITLE
configure: Automaticaly detect the default xorg-module-dir.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,9 +45,12 @@ LT_INIT([disable-static])
 AH_TOP([#include "xorg-server.h"])
 
 # Define a configure option for an alternate module directory
-AC_ARG_WITH(xorg-module-dir, [  --with-xorg-module-dir=DIR ],
-                             [ moduledir="$withval" ],
-                             [ moduledir="$libdir/xorg/modules" ])
+PKG_PROG_PKG_CONFIG([0.25])
+AC_ARG_WITH(xorg-module-dir,
+            AS_HELP_STRING([--with-xorg-module-dir=DIR],
+                           [Default xorg module directory]),
+            [moduledir="$withval"],
+            [moduledir=`$PKG_CONFIG --variable=moduledir xorg-server`])
 AC_SUBST(moduledir)
 
 


### PR DESCRIPTION
Related [our discussion](https://github.com/orgs/X11Libre/discussions/97).

The module directory has changed to a per ABI folder in the xlibre-xserver. 
Now the default value of `xorg-module-dir` will be detected from the 'moduledir' variable in xorg-server.pc.

None of the drivers configure.ac files detect the `moduledir` automatically.
I just created this single PR, to see how things should be handled, if its all OK, I can make PRs for the other drivers too.